### PR TITLE
Add pyupgrade pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -43,7 +43,7 @@ repos:
           - toml
         files: ^(package_name|tests)/.+\.py$
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.910
+    rev: v0.950
     hooks:
       - id: mypy
         files: ^package_name/.+\.py$
@@ -65,3 +65,7 @@ repos:
     hooks:
       - id: shellcheck
         files: ^script/.+
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.32.1
+    hooks:
+      - id: pyupgrade


### PR DESCRIPTION
**Describe what the PR does:**

This PR adds the [`pyupgrade`](https://github.com/asottile/pyupgrade) pre-commit hook to help us take advantage of new Python features depending on what versions we support.

**Does this fix a specific issue?**

N/A
  
**Checklist:**

- [ ] Confirm that one or more new tests are written for the new functionality.
- [x] Run tests and ensure everything passes (with 100% test coverage).
- [ ] Update `README.md` and `docs/` with any new documentation.
- [ ] Add yourself to `AUTHORS.md`.
